### PR TITLE
Aether compatibility for elytra cape skins.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -179,6 +179,8 @@ dependencies {
 
     runtimeOnly fg.deobf("top.theillusivec4.curios:curios-forge:${curios_version}")
     compileOnly fg.deobf("top.theillusivec4.curios:curios-forge:${curios_version}:api")
+
+    //compileOnly fileTree(dir: 'libs', include: '*.jar')
 }
 
 mixin {

--- a/src/main/java/com/hidoni/customizableelytra/CustomizableElytra.java
+++ b/src/main/java/com/hidoni/customizableelytra/CustomizableElytra.java
@@ -21,6 +21,7 @@ public class CustomizableElytra
     public static final Logger LOGGER = LogManager.getLogger();
     public static boolean caelusLoaded = false;
     public static boolean curiosLoaded = false;
+    public static boolean aetherLoaded = false;
 
     public CustomizableElytra()
     {
@@ -39,7 +40,7 @@ public class CustomizableElytra
         }
         curiosLoaded = ModList.get().isLoaded("curios");
         MinecraftForge.EVENT_BUS.register(new EntityConstructingHandler());
-
+        aetherLoaded = ModList.get().isLoaded("aether");
     }
 
     private void clientLoadingEvent(final FMLClientSetupEvent event)

--- a/src/main/java/com/hidoni/customizableelytra/renderers/CustomizableElytraLayer.java
+++ b/src/main/java/com/hidoni/customizableelytra/renderers/CustomizableElytraLayer.java
@@ -1,5 +1,6 @@
 package com.hidoni.customizableelytra.renderers;
 
+import com.gildedgames.aether.common.item.accessories.cape.CapeItem;
 import com.google.common.collect.ImmutableList;
 import com.hidoni.customizableelytra.CustomizableElytra;
 import com.hidoni.customizableelytra.items.CustomizableElytraItem;
@@ -25,6 +26,8 @@ import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.util.ResourceLocation;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import top.theillusivec4.curios.api.CuriosApi;
+import top.theillusivec4.curios.api.type.capability.ICuriosItemHandler;
+import top.theillusivec4.curios.api.type.inventory.ICurioStacksHandler;
 
 import java.util.List;
 import java.util.Optional;
@@ -107,6 +110,24 @@ public class CustomizableElytraLayer<T extends LivingEntity, M extends EntityMod
     @Override
     public ResourceLocation getElytraTexture(ItemStack stack, T entity)
     {
+        if (CustomizableElytra.aetherLoaded)
+        {
+            Optional<ImmutableTriple<String, Integer, ItemStack>> curiosHelper = CuriosApi.getCuriosHelper().findEquippedCurio((item) -> item.getItem() instanceof CapeItem, entity);
+            Optional<ICuriosItemHandler> curiosHandler = CuriosApi.getCuriosHelper().getCuriosHandler(entity).resolve();
+            if (curiosHelper.isPresent() && curiosHandler.isPresent())
+            {
+                Optional<ICurioStacksHandler> stacksHandler = curiosHandler.get().getStacksHandler(curiosHelper.get().getLeft());
+                if (stacksHandler.isPresent())
+                {
+                    CapeItem cape = (CapeItem) curiosHelper.get().getRight().getItem();
+                    if (cape.getCapeTexture() != null && stacksHandler.get().getRenders().get(curiosHelper.get().getMiddle()))
+                    {
+                        return ElytraTextureUtil.getGrayscale(cape.getCapeTexture());
+                    }
+                }
+            }
+        }
+
         if (stack.getItem() == ModItems.CUSTOMIZABLE_ELYTRA.get())
         {
             if (((CustomizableElytraItem) stack.getItem()).hasColor(stack))
@@ -114,6 +135,7 @@ public class CustomizableElytraLayer<T extends LivingEntity, M extends EntityMod
                 return TEXTURE_DYEABLE_ELYTRA;
             }
         }
+
         return super.getElytraTexture(stack, entity);
     }
 


### PR DESCRIPTION
Implemented compatibility with the Aether mod so that the mod's cape skins for Elytras can also display on Customized Elytras.

NOTE: As the Aether port for 1.16 is not actually released on Curseforge and is only on GitHub, to avoid workspace crashing, Aether will have to be added locally to the workspace (unless there is a better way to handle this that I don't know of, and if there is and it can be done on my end I will gladly make adjustments to this PR). I used the now commented out `compileOnly fileTree(dir: 'libs', include: '*.jar')` code in build.gradle to handle this on my end for development, with the libs folder in the main workspace directory being where I put a built Aether jar (this is the latest as of the time I'm making this PR: https://app.circleci.com/pipelines/github/Gilded-Games/The-Aether/171/workflows/ee16ca29-8fea-4cf5-ba00-92a937376526/jobs/176/artifacts)

![image](https://user-images.githubusercontent.com/67203206/124230841-62257800-dac4-11eb-8f32-0fd158aa4d37.png)
![image](https://user-images.githubusercontent.com/67203206/124230855-66ea2c00-dac4-11eb-8bf9-7751245c403e.png)