### PR TITLE
[1.21] Rewrite mixins to use MixinExtra

### DIFF
--- a/Common/build.gradle
+++ b/Common/build.gradle
@@ -16,6 +16,7 @@ minecraft {
 
 dependencies {
     compileOnly group: 'org.spongepowered', name: 'mixin', version: '0.8.5'
+    compileOnly group: 'io.github.llamalad7', name: 'mixinextras-common', version: '0.4.1'
     implementation group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.1'
 }
 

--- a/Common/src/main/java/com/hidoni/customizableelytra/client/CustomizableElytraLayerHelper.java
+++ b/Common/src/main/java/com/hidoni/customizableelytra/client/CustomizableElytraLayerHelper.java
@@ -1,7 +1,6 @@
 package com.hidoni.customizableelytra.client;
 
 import com.hidoni.customizableelytra.Constants;
-import com.hidoni.customizableelytra.customization.CustomizationUtils;
 import com.hidoni.customizableelytra.item.CustomizableElytraItem;
 import com.hidoni.customizableelytra.mixin.TextureAtlasAccessor;
 import com.hidoni.customizableelytra.render.ElytraWingModel;
@@ -39,9 +38,6 @@ public class CustomizableElytraLayerHelper<T extends LivingEntity> {
     private static final Function<ArmorTrim, ResourceLocation> elytraTrimLookup = Util.memoize(trim -> trim.pattern().value().assetId().withPath((path) -> "trims/models/elytra/" + path + "_" + trim.material().value().assetName()));
     private static final ResourceLocation VANILLA_WINGS_LOCATION = ResourceLocation.withDefaultNamespace("textures/entity/elytra.png");
 
-    private T entity = null;
-    private MultiBufferSource defaultBuffer = null;
-    private ItemStack elytra = null;
     private final TextureAtlas bannerPatternAtlas;
     private final TextureAtlas armorTrimAtlas;
 
@@ -50,54 +46,34 @@ public class CustomizableElytraLayerHelper<T extends LivingEntity> {
         armorTrimAtlas = getAtlas(Sheets.ARMOR_TRIMS_SHEET);
     }
 
-    public void setEntity(T entity) {
-        this.entity = entity;
-    }
-
-    public T getEntity() {
-        return entity;
-    }
-
-    public void setDefaultBuffer(MultiBufferSource defaultBuffer) {
-        this.defaultBuffer = defaultBuffer;
-    }
-
-    public void setElytra(ItemStack elytra) {
-        this.elytra = elytra;
-    }
-
-    public ItemStack getElytra() {
-        return elytra;
-    }
-
-    public void renderWing(ElytraWingModel<T> wingModel, ItemStack wingStack, PoseStack poseStack, VertexConsumer vertexConsumer, int packedLight, boolean hasFoil) {
+    public void renderWing(ElytraWingModel<T> wingModel, ItemStack wingStack, PoseStack poseStack, VertexConsumer vertexConsumer, MultiBufferSource buffer, int packedLight, boolean hasFoil, LivingEntity entity) {
         CustomizableElytraItem wingItem = (CustomizableElytraItem) wingStack.getItem();
         if (wingItem.isGlowing(wingStack)) {
             packedLight |= 0xFF;
         }
         if (wingItem.isDyed(wingStack)) {
-            renderDyedWing(wingModel, wingStack, poseStack, packedLight, wingItem, getGrayscaleTexture(wingItem.isCapeHidden(wingStack)), hasFoil);
+            renderDyedWing(wingModel, wingStack, poseStack, buffer, packedLight, wingItem, getGrayscaleTexture(entity, wingItem.isCapeHidden(wingStack)), hasFoil);
         } else if (wingItem.hasBanner(wingStack)) {
-            renderWingBannerPatterns(wingModel, wingStack, poseStack, packedLight, wingItem, getGrayscaleTexture(wingItem.isCapeHidden(wingStack)), hasFoil);
+            renderWingBannerPatterns(wingModel, wingStack, poseStack, buffer, packedLight, wingItem, getGrayscaleTexture(entity, wingItem.isCapeHidden(wingStack)), hasFoil);
         } else {
-            renderBasicWing(wingModel, wingStack, poseStack, packedLight, wingItem, hasFoil);
+            renderBasicWing(wingModel, wingStack, poseStack, buffer, packedLight, wingItem, hasFoil, entity);
         }
         if (wingItem.hasArmorTrim(wingStack)) {
-            renderWingTrim(wingModel, wingStack, poseStack, packedLight, wingItem, hasFoil);
+            renderWingTrim(wingModel, wingStack, poseStack, buffer, packedLight, wingItem, hasFoil);
         }
     }
 
-    private void renderDyedWing(ElytraWingModel<T> wingModel, ItemStack wingStack, PoseStack poseStack, int packedLight, CustomizableElytraItem wingItem, ResourceLocation elytraTexture, boolean hasFoil) {
-        VertexConsumer elytraVertexConsumer = ItemRenderer.getArmorFoilBuffer(defaultBuffer, RenderType.armorCutoutNoCull(elytraTexture), hasFoil);
+    private void renderDyedWing(ElytraWingModel<T> wingModel, ItemStack wingStack, PoseStack poseStack, MultiBufferSource buffer, int packedLight, CustomizableElytraItem wingItem, ResourceLocation elytraTexture, boolean hasFoil) {
+        VertexConsumer elytraVertexConsumer = ItemRenderer.getArmorFoilBuffer(buffer, RenderType.armorCutoutNoCull(elytraTexture), hasFoil);
         wingModel.renderToBuffer(poseStack, elytraVertexConsumer, packedLight, OverlayTexture.NO_OVERLAY, wingItem.getColor(wingStack));
     }
 
-    private void renderWingBannerPatterns(ElytraWingModel<T> wingModel, ItemStack wingStack, PoseStack poseStack, int packedLight, CustomizableElytraItem wingItem, ResourceLocation elytraTexture, boolean hasFoil) {
+    private void renderWingBannerPatterns(ElytraWingModel<T> wingModel, ItemStack wingStack, PoseStack poseStack, MultiBufferSource buffer, int packedLight, CustomizableElytraItem wingItem, ResourceLocation elytraTexture, boolean hasFoil) {
         BannerPatternLayers bannerPatterns = wingItem.getBannerPatterns(wingStack);
         // First render: Enchantment Glint
-        wingModel.renderToBuffer(poseStack, ItemRenderer.getFoilBufferDirect(defaultBuffer, RenderType.entityNoOutline(elytraTexture), false, hasFoil), packedLight, OverlayTexture.NO_OVERLAY);
+        wingModel.renderToBuffer(poseStack, ItemRenderer.getFoilBufferDirect(buffer, RenderType.entityNoOutline(elytraTexture), false, hasFoil), packedLight, OverlayTexture.NO_OVERLAY);
         // Second render: Base Layer
-        wingModel.renderToBuffer(poseStack, ItemRenderer.getFoilBuffer(defaultBuffer, RenderType.entityTranslucent(elytraTexture), false, false), packedLight, OverlayTexture.NO_OVERLAY, wingItem.getBaseColor(wingStack).getTextureDiffuseColor());
+        wingModel.renderToBuffer(poseStack, ItemRenderer.getFoilBuffer(buffer, RenderType.entityTranslucent(elytraTexture), false, false), packedLight, OverlayTexture.NO_OVERLAY, wingItem.getBaseColor(wingStack).getTextureDiffuseColor());
         for (int i = 0; i < bannerPatterns.layers().size(); i++) {
             BannerPatternLayers.Layer bannerAndColor = bannerPatterns.layers().get(i);
             Optional<ResourceKey<BannerPattern>> resourceKey = bannerAndColor.pattern().unwrapKey();
@@ -107,21 +83,21 @@ public class CustomizableElytraLayerHelper<T extends LivingEntity> {
                 if (texturesByName.get(bannerMaterial.texture()) != null) // Don't render this banner pattern if it's missing, silently hide the pattern
                 {
                     // Final renders: Pattern Layers
-                    wingModel.renderToBuffer(poseStack, bannerMaterial.buffer(defaultBuffer, RenderType::entityTranslucent), packedLight, OverlayTexture.NO_OVERLAY, bannerAndColor.color().getTextureDiffuseColor());
+                    wingModel.renderToBuffer(poseStack, bannerMaterial.buffer(buffer, RenderType::entityTranslucent), packedLight, OverlayTexture.NO_OVERLAY, bannerAndColor.color().getTextureDiffuseColor());
                 }
             }
         }
     }
 
-    private void renderBasicWing(ElytraWingModel<T> wingModel, ItemStack wingStack, PoseStack poseStack, int packedLight, CustomizableElytraItem wingItem, boolean hasFoil) {
+    private void renderBasicWing(ElytraWingModel<T> wingModel, ItemStack wingStack, PoseStack poseStack, MultiBufferSource buffer, int packedLight, CustomizableElytraItem wingItem, boolean hasFoil, LivingEntity entity) {
         ResourceLocation elytraTexture = null;
         if (!wingItem.isCapeHidden(wingStack)) {
-            elytraTexture = getCapeTexture();
+            elytraTexture = getCapeTexture(entity);
         }
         if (elytraTexture == null) {
             elytraTexture = VANILLA_WINGS_LOCATION;
         }
-        VertexConsumer vertexConsumer = ItemRenderer.getArmorFoilBuffer(defaultBuffer, RenderType.armorCutoutNoCull(elytraTexture), hasFoil);
+        VertexConsumer vertexConsumer = ItemRenderer.getArmorFoilBuffer(buffer, RenderType.armorCutoutNoCull(elytraTexture), hasFoil);
         wingModel.renderToBuffer(poseStack, vertexConsumer, packedLight, OverlayTexture.NO_OVERLAY);
     }
 
@@ -130,21 +106,21 @@ public class CustomizableElytraLayerHelper<T extends LivingEntity> {
         return Minecraft.getInstance().getModelManager().getAtlas(location);
     }
 
-    private void renderWingTrim(ElytraWingModel<T> wingModel, ItemStack wingStack, PoseStack poseStack, int packedLight, CustomizableElytraItem wingItem, boolean hasFoil) {
+    private void renderWingTrim(ElytraWingModel<T> wingModel, ItemStack wingStack, PoseStack poseStack, MultiBufferSource buffer, int packedLight, CustomizableElytraItem wingItem, boolean hasFoil) {
         Optional<ArmorTrim> armorTrim = wingItem.getArmorTrim(wingStack);
         armorTrim.ifPresent((trim) -> {
             ResourceLocation trimLocation = elytraTrimLookup.apply(trim);
             TextureAtlasSprite sprite = armorTrimAtlas.getSprite(trimLocation);
-            VertexConsumer consumer = sprite.wrap(ItemRenderer.getFoilBufferDirect(defaultBuffer, Sheets.armorTrimsSheet(trim.pattern().value().decal()), true, hasFoil));
+            VertexConsumer consumer = sprite.wrap(ItemRenderer.getFoilBufferDirect(buffer, Sheets.armorTrimsSheet(trim.pattern().value().decal()), true, hasFoil));
             wingModel.renderToBuffer(poseStack, consumer, packedLight, OverlayTexture.NO_OVERLAY);
         });
     }
 
 
-    private ResourceLocation getGrayscaleTexture(boolean capeHidden) {
+    private ResourceLocation getGrayscaleTexture(LivingEntity entity, boolean capeHidden) {
         ResourceLocation elytraTexture = null;
         if (!capeHidden) {
-            elytraTexture = getCapeTexture();
+            elytraTexture = getCapeTexture(entity);
         }
         if (elytraTexture != null) {
             return TextureUtils.getGrayscale(elytraTexture);
@@ -152,7 +128,7 @@ public class CustomizableElytraLayerHelper<T extends LivingEntity> {
         return TEXTURE_GRAYSCALE_ELYTRA;
     }
 
-    private ResourceLocation getCapeTexture() {
+    private ResourceLocation getCapeTexture(LivingEntity entity) {
         if (entity instanceof AbstractClientPlayer clientPlayer) {
             PlayerSkin skin = clientPlayer.getSkin();
             if (skin.elytraTexture() != null) {

--- a/Common/src/main/java/com/hidoni/customizableelytra/mixin/ColytraLayerMixin.java
+++ b/Common/src/main/java/com/hidoni/customizableelytra/mixin/ColytraLayerMixin.java
@@ -48,7 +48,7 @@ public abstract class ColytraLayerMixin<T extends LivingEntity, M extends Entity
 
     @Redirect(method = "*", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/model/ElytraModel;renderToBuffer(Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;III)V"))
     private void renderCustomizedElytraWings(ElytraModel<T> elytraModel, PoseStack poseStack, VertexConsumer vertexConsumer, int packedLight, int overlayTexture, int argb,
-                                             @Local(argsOnly = true) MultiBufferSource buffer, @Local(argsOnly = true) LivingEntity entity, @Local ItemStack elytra) {
+                                             @Local(argsOnly = true) MultiBufferSource buffer, @Local(argsOnly = true) LivingEntity entity, @Local(name = "elytraStack") ItemStack elytra) {
         ElytraCustomization customization = CustomizationUtils.getElytraCustomization(elytra);
         if (!customization.isCustomized()) {
             elytraModel.renderToBuffer(poseStack, vertexConsumer, packedLight, overlayTexture, argb);

--- a/Common/src/main/java/com/hidoni/customizableelytra/mixin/ColytraLayerMixin.java
+++ b/Common/src/main/java/com/hidoni/customizableelytra/mixin/ColytraLayerMixin.java
@@ -4,6 +4,7 @@ import com.hidoni.customizableelytra.client.CustomizableElytraLayerHelper;
 import com.hidoni.customizableelytra.customization.CustomizationUtils;
 import com.hidoni.customizableelytra.customization.ElytraCustomization;
 import com.hidoni.customizableelytra.render.ElytraWingModel;
+import com.llamalad7.mixinextras.sugar.Local;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.model.ElytraModel;
@@ -20,7 +21,6 @@ import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
@@ -46,28 +46,17 @@ public abstract class ColytraLayerMixin<T extends LivingEntity, M extends Entity
         helper = new CustomizableElytraLayerHelper<>();
     }
 
-    @Inject(method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/world/entity/LivingEntity;FFFFFF)V", at = @At("HEAD"))
-    private void storeRenderArguments(PoseStack matrixStack, MultiBufferSource buffer, int packedLight, T livingEntity, float limbSwing, float limbSwingAmount, float partialTicks, float ageInTicks, float netHeadYaw, float headPitch, CallbackInfo ci) {
-        helper.setEntity(livingEntity);
-        helper.setDefaultBuffer(buffer);
-    }
-
-    @ModifyVariable(method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/world/entity/LivingEntity;FFFFFF)V", at = @At("STORE"), ordinal = 1)
-    private ItemStack storeElytraStack(ItemStack elytra) {
-        helper.setElytra(elytra);
-        return elytra;
-    }
-
     @Redirect(method = "*", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/model/ElytraModel;renderToBuffer(Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;III)V"))
-    private void renderCustomizedElytraWings(ElytraModel<T> elytraModel, PoseStack poseStack, VertexConsumer vertexConsumer, int packedLight, int overlayTexture, int argb) {
-        ElytraCustomization customization = CustomizationUtils.getElytraCustomization(helper.getElytra());
+    private void renderCustomizedElytraWings(ElytraModel<T> elytraModel, PoseStack poseStack, VertexConsumer vertexConsumer, int packedLight, int overlayTexture, int argb,
+                                             @Local(argsOnly = true) MultiBufferSource buffer, @Local(argsOnly = true) LivingEntity entity, @Local ItemStack elytra) {
+        ElytraCustomization customization = CustomizationUtils.getElytraCustomization(elytra);
         if (!customization.isCustomized()) {
             elytraModel.renderToBuffer(poseStack, vertexConsumer, packedLight, overlayTexture, argb);
             return;
         }
         getParentModel().copyPropertiesTo(leftWing);
         getParentModel().copyPropertiesTo(rightWing);
-        helper.renderWing(leftWing, customization.leftWing(), poseStack, vertexConsumer, packedLight, helper.getElytra().hasFoil());
-        helper.renderWing(rightWing, customization.rightWing(), poseStack, vertexConsumer, packedLight, helper.getElytra().hasFoil());
+        helper.renderWing(leftWing, customization.leftWing(), poseStack, vertexConsumer, buffer, packedLight, elytra.hasFoil(), entity);
+        helper.renderWing(rightWing, customization.rightWing(), poseStack, vertexConsumer, buffer, packedLight, elytra.hasFoil(), entity);
     }
 }

--- a/Common/src/main/java/com/hidoni/customizableelytra/mixin/ElytraLayerMixin.java
+++ b/Common/src/main/java/com/hidoni/customizableelytra/mixin/ElytraLayerMixin.java
@@ -4,6 +4,7 @@ import com.hidoni.customizableelytra.client.CustomizableElytraLayerHelper;
 import com.hidoni.customizableelytra.customization.CustomizationUtils;
 import com.hidoni.customizableelytra.customization.ElytraCustomization;
 import com.hidoni.customizableelytra.render.ElytraWingModel;
+import com.llamalad7.mixinextras.sugar.Local;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.model.ElytraModel;
@@ -21,7 +22,6 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
@@ -48,28 +48,17 @@ public abstract class ElytraLayerMixin<T extends LivingEntity, M extends EntityM
         helper = new CustomizableElytraLayerHelper<>();
     }
 
-    @Inject(method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/world/entity/LivingEntity;FFFFFF)V", at = @At("HEAD"))
-    private void storeRenderArguments(PoseStack matrixStack, MultiBufferSource buffer, int packedLight, T livingEntity, float limbSwing, float limbSwingAmount, float partialTicks, float ageInTicks, float netHeadYaw, float headPitch, CallbackInfo ci) {
-        helper.setEntity(livingEntity);
-        helper.setDefaultBuffer(buffer);
-    }
-
-    @ModifyVariable(method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/world/entity/LivingEntity;FFFFFF)V", at = @At("STORE"), ordinal = 0)
-    private ItemStack storeElytraStack(ItemStack elytra) {
-        helper.setElytra(elytra);
-        return elytra;
-    }
-
     @Redirect(method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/world/entity/LivingEntity;FFFFFF)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/model/ElytraModel;renderToBuffer(Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;II)V"))
-    private void renderCustomizedElytraWings(ElytraModel<T> elytraModel, PoseStack poseStack, VertexConsumer vertexConsumer, int packedLight, int overlayTexture) {
-        ElytraCustomization customization = CustomizationUtils.getElytraCustomization(helper.getElytra());
+    private void renderCustomizedElytraWings(ElytraModel<T> elytraModel, PoseStack poseStack, VertexConsumer vertexConsumer, int packedLight, int overlayTexture,
+                                             @Local(argsOnly = true) MultiBufferSource buffer, @Local(argsOnly = true) LivingEntity entity, @Local ItemStack elytra) {
+        ElytraCustomization customization = CustomizationUtils.getElytraCustomization(elytra);
         if (!customization.isCustomized()) {
             elytraModel.renderToBuffer(poseStack, vertexConsumer, packedLight, overlayTexture);
             return;
         }
         getParentModel().copyPropertiesTo(leftWing);
         getParentModel().copyPropertiesTo(rightWing);
-        helper.renderWing(leftWing, customization.leftWing(), poseStack, vertexConsumer, packedLight, helper.getElytra().hasFoil());
-        helper.renderWing(rightWing, customization.rightWing(), poseStack, vertexConsumer, packedLight, helper.getElytra().hasFoil());
+        helper.renderWing(leftWing, customization.leftWing(), poseStack, vertexConsumer, buffer, packedLight, elytra.hasFoil(), entity);
+        helper.renderWing(rightWing, customization.rightWing(), poseStack, vertexConsumer, buffer, packedLight, elytra.hasFoil(), entity);
     }
 }

--- a/Common/src/main/java/com/hidoni/customizableelytra/mixin/ElytraSlotLayerMixin.java
+++ b/Common/src/main/java/com/hidoni/customizableelytra/mixin/ElytraSlotLayerMixin.java
@@ -4,6 +4,11 @@ import com.hidoni.customizableelytra.client.CustomizableElytraLayerHelper;
 import com.hidoni.customizableelytra.customization.CustomizationUtils;
 import com.hidoni.customizableelytra.customization.ElytraCustomization;
 import com.hidoni.customizableelytra.render.ElytraWingModel;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.model.ElytraModel;
@@ -46,29 +51,24 @@ public abstract class ElytraSlotLayerMixin<T extends LivingEntity, M extends Ent
         helper = new CustomizableElytraLayerHelper<>();
     }
 
-    @Inject(method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/world/entity/LivingEntity;FFFFFF)V", at = @At("HEAD"))
-    private void storeRenderArguments(PoseStack matrixStack, MultiBufferSource buffer, int packedLight, T livingEntity, float limbSwing, float limbSwingAmount, float partialTicks, float ageInTicks, float netHeadYaw, float headPitch, CallbackInfo ci) {
-        helper.setEntity(livingEntity);
-        helper.setDefaultBuffer(buffer);
-    }
-
     // Elytra Slot runs everything in a lambda, so to make life easy we target all methods to inject (should still only be one match!)
-    @Redirect(method = "*", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/ItemStack;getItem()Lnet/minecraft/world/item/Item;"))
-    private Item storeElytraStack(ItemStack elytra) {
-        helper.setElytra(elytra);
-        return elytra.getItem();
+    @WrapOperation(method = "*", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/ItemStack;getItem()Lnet/minecraft/world/item/Item;"))
+    private static Item storeElytraStack(ItemStack elytra, Operation<Item> operation, @Share("elytra") LocalRef<ItemStack> stack) {
+        stack.set(elytra);
+        return operation.call(elytra);
     }
 
     @Redirect(method = "*", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/model/ElytraModel;renderToBuffer(Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;III)V"))
-    private void renderCustomizedElytraWings(ElytraModel<T> elytraModel, PoseStack poseStack, VertexConsumer vertexConsumer, int packedLight, int overlayTexture, int argb) {
-        ElytraCustomization customization = CustomizationUtils.getElytraCustomization(helper.getElytra());
+    private void renderCustomizedElytraWings(ElytraModel<T> elytraModel, PoseStack poseStack, VertexConsumer vertexConsumer, int packedLight, int overlayTexture, int argb,
+                                             @Local(argsOnly = true) MultiBufferSource buffer, @Local(argsOnly = true) LivingEntity entity, @Share("elytra") LocalRef<ItemStack> elytra) {
+        ElytraCustomization customization = CustomizationUtils.getElytraCustomization(elytra.get());
         if (!customization.isCustomized()) {
             elytraModel.renderToBuffer(poseStack, vertexConsumer, packedLight, overlayTexture, argb);
             return;
         }
         getParentModel().copyPropertiesTo(leftWing);
         getParentModel().copyPropertiesTo(rightWing);
-        helper.renderWing(leftWing, customization.leftWing(), poseStack, vertexConsumer, packedLight, helper.getElytra().hasFoil());
-        helper.renderWing(rightWing, customization.rightWing(), poseStack, vertexConsumer, packedLight, helper.getElytra().hasFoil());
+        helper.renderWing(leftWing, customization.leftWing(), poseStack, vertexConsumer, buffer, packedLight, elytra.get().hasFoil(), entity);
+        helper.renderWing(rightWing, customization.rightWing(), poseStack, vertexConsumer, buffer, packedLight, elytra.get().hasFoil(), entity);
     }
 }

--- a/Forge/build.gradle
+++ b/Forge/build.gradle
@@ -80,6 +80,11 @@ dependencies {
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
     annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
 
+    compileOnly(annotationProcessor("io.github.llamalad7:mixinextras-common:0.4.1"))
+    implementation(jarJar("io.github.llamalad7:mixinextras-forge:0.4.1")) {
+        jarJar.ranged(it, "[0.4.1,)")
+    }
+
     implementation('net.sf.jopt-simple:jopt-simple:5.0.4') { version { strictly '5.0.4' } }
 
     compileOnly project(":Common")


### PR DESCRIPTION
Colytra untested as it does not exist on 1.21.1. Presumably, it should work if it does.

This also aids in removing memleaks caused from entities being permanently retained by the helper.

Note: The Forge build will be heavier as a result due to needing to bundle MixinExtras manually.